### PR TITLE
fix _JAVA_OPTIONS causing a crash

### DIFF
--- a/app/assets/js/processbuilder.js
+++ b/app/assets/js/processbuilder.js
@@ -73,9 +73,16 @@ class ProcessBuilder {
 
         logger.info('Launch Arguments:', args)
 
+        if (process.env['_JAVA_OPTIONS']) {
+            logger.warn('Detected _JAVA_OPTIONS environment variable. This can cause issues with the launcher, so it has been overridden.')   
+        }
+
         const child = child_process.spawn(ConfigManager.getJavaExecutable(this.server.rawServer.id), args, {
             cwd: this.gameDir,
-            detached: ConfigManager.getLaunchDetached()
+            detached: ConfigManager.getLaunchDetached(),
+            env: {
+                '_JAVA_OPTIONS': ''
+            }
         })
 
         if(ConfigManager.getLaunchDetached()){


### PR DESCRIPTION
Sets the variable to an empty string, overriding anything already there
A bodge for now, may need a more proper solution if problems continue