### PR TITLE
Add launcher logs and x64 Linux build

### DIFF
--- a/app/assets/js/logger.js
+++ b/app/assets/js/logger.js
@@ -1,0 +1,72 @@
+const { app } = process.type === 'browser' ? require('electron') : require('@electron/remote')
+const winston = require('winston')
+const path = require('path')
+const fs = require('fs')
+
+// custom logging transport that behaves like the game
+// not native to Winston
+class FileLoggingTransport extends winston.Transport {
+
+    constructor(options) {
+        super(options)
+        this.logFileName = options.logFileName || 'app'
+        this.logFileExt = options.logFileExt || 'log'
+        this.maxLogFiles = options.maxLogFiles || 1
+    }
+
+    getStream() {
+        if (this.stream) return this.stream
+
+        const dirName = path.join(app.getPath('userData'), 'logs')
+        const fileName = `${this.logFileName}-latest.${this.logFileExt}`
+        const fileNameFull = path.join(dirName, fileName)
+
+        try {
+            const latestStats = fs.statSync(fileNameFull)
+            fs.renameSync(fileNameFull, path.join(dirName, `${this.logFileName}-${Math.floor(latestStats.atimeMs)}.${this.logFileExt}`))
+        } catch (e) {
+            if (e.code !== 'ENOENT' && e.code !== 'EBUSY') throw e
+        }
+
+        const stream = fs.createWriteStream(fileNameFull, { flags: 'a' })
+        this.stream = stream
+
+        const files = fs.readdirSync(dirName)
+        if (files.length > this.maxLogFiles) {
+            const oldFiles = files
+                .map(file => ({ file, stats: fs.lstatSync(path.join(dirName, file)) }))
+                .sort((a, b) => b.stats.birthtimeMs - a.stats.birthtimeMs)
+                .slice(this.maxLogFiles)
+            oldFiles.forEach(({ file }) => fs.rmSync(path.join(dirName, file)))
+        }
+
+        return stream
+    }
+
+    log(info, callback) {
+        const message = info[Symbol.for('message')]
+        this.getStream().write(`${message}\n`, callback)
+    }
+}
+
+const fileTransport = new FileLoggingTransport({
+    format: winston.format.uncolorize(),
+    logFileName: 'launcher',
+    maxLogFiles: 5
+})
+
+/**
+ * Reconfigures the logger
+ *
+ * The default Helios logger creates a Winston logger that only has a console transport. This changes it a bit
+ * and adds a file transport to the logger.
+ * @param {Function} loggerFactory The logger factory function
+ * @returns {Function} The new logger factory function
+ */
+exports.reconfigureLogger = function (loggerFactory) {
+    return function (...args) {
+        const logger = loggerFactory(...args)
+        logger.add(fileTransport)
+        return logger
+    }
+}

--- a/app/assets/js/logger.js
+++ b/app/assets/js/logger.js
@@ -17,7 +17,7 @@ class FileLoggingTransport extends winston.Transport {
     getStream() {
         if (this.stream) return this.stream
 
-        const dirName = path.join(app.getPath('userData'), 'logs')
+        const dirName = app.getPath('logs')
         const fileName = `${this.logFileName}-latest.${this.logFileExt}`
         const fileNameFull = path.join(dirName, fileName)
 
@@ -54,6 +54,7 @@ const fileTransport = new FileLoggingTransport({
     logFileName: 'launcher',
     maxLogFiles: 5
 })
+fileTransport.setMaxListeners(30)
 
 /**
  * Reconfigures the logger

--- a/app/assets/js/preloader.js
+++ b/app/assets/js/preloader.js
@@ -3,12 +3,18 @@ const fs             = require('fs-extra')
 const os             = require('os')
 const path           = require('path')
 
+const { LoggerUtil } = require('helios-core')
+
+/** @type import("../logger") */
+const { reconfigureLogger } = require('./logger')
+LoggerUtil.getLogger = reconfigureLogger(LoggerUtil.getLogger)
+
 const ConfigManager  = require('./configmanager')
 const { DistroAPI }  = require('./distromanager')
 const LangLoader     = require('./langloader')
-const { LoggerUtil } = require('helios-core')
 // eslint-disable-next-line no-unused-vars
 const { HeliosDistribution } = require('helios-core/common')
+
 
 const logger = LoggerUtil.getLogger('Preloader')
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -38,7 +38,12 @@ mac:
 
 # Linux Configuration
 linux:
-  target: 'AppImage'
+  target:
+    - target: 'AppImage'
+      arch:
+        - 'x64'
+        - 'arm64'
+  artifactName: '${productName}-setup-${version}-${arch}.${ext}'
   maintainer: 'Fairy Jeux'
   vendor: 'Fairy Jeux'
   synopsis: 'Modded Minecraft Launcher for Create Academy'


### PR DESCRIPTION
The launcher now actually outputs log files. They can be found in:

- Windows: `%APPDATA%\Create Academy Launcher\logs`
- Linux: `$XDG_CONFIG_HOME/Create Academy Launcher/logs` or `~/.config/Create Academy Launcher/logs`
- macOS: `~/Library/Application Support/Create Academy Launcher/logs`

Edit:
I have also added builds for `x64` and `arm64` on Linux.
The default was in-fact not x64 but *current platform*, and the runner is arm64 Linux.
Closes [DIS-13](https://discord.com/channels/1138859263490523227/1272636981133705391).